### PR TITLE
fix: add favicon and Creatorlayer branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Creatorlayer Status</title>
+  <title>Creatorlayer — Status</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%234F98A3'/><text x='16' y='22' text-anchor='middle' fill='white' font-family='system-ui' font-size='16' font-weight='700'>CL</text></svg>">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-      background: #f6f8fa;
-      color: #24292f;
+      background: #0B0C10;
+      color: #e6edf3;
       min-height: 100vh;
       padding: 48px 16px;
     }
     .container { max-width: 680px; margin: 0 auto; }
     header { margin-bottom: 40px; }
     header h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 4px; }
-    header p { color: #57606a; font-size: 0.9rem; }
+    header p { color: #8b949e; font-size: 0.9rem; }
     .banner {
       border-radius: 8px;
       padding: 16px 20px;
@@ -24,12 +25,12 @@
       margin-bottom: 32px;
       font-size: 0.95rem;
     }
-    .banner.all-up   { background: #dafbe1; color: #1a7f37; border: 1px solid #aceebb; }
-    .banner.some-down { background: #fff8c5; color: #9a6700; border: 1px solid #f0d070; }
-    .banner.loading  { background: #eef0f3; color: #57606a; border: 1px solid #d0d7de; }
-    .services { display: flex; flex-direction: column; gap: 1px; border-radius: 8px; overflow: hidden; border: 1px solid #d0d7de; }
+    .banner.all-up   { background: rgba(79,152,163,0.15); color: #4F98A3; border: 1px solid rgba(79,152,163,0.3); }
+    .banner.some-down { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
+    .banner.loading  { background: rgba(139,148,158,0.1); color: #8b949e; border: 1px solid rgba(139,148,158,0.2); }
+    .services { display: flex; flex-direction: column; gap: 1px; border-radius: 8px; overflow: hidden; border: 1px solid #21262d; }
     .service {
-      background: #fff;
+      background: #161b22;
       padding: 16px 20px;
       display: flex;
       align-items: center;
@@ -37,7 +38,7 @@
       gap: 12px;
     }
     .service-name { font-weight: 500; font-size: 0.95rem; }
-    .service-meta { color: #57606a; font-size: 0.8rem; margin-top: 2px; }
+    .service-meta { color: #8b949e; font-size: 0.8rem; margin-top: 2px; }
     .badge {
       display: inline-flex;
       align-items: center;
@@ -49,20 +50,20 @@
       white-space: nowrap;
       flex-shrink: 0;
     }
-    .badge.up       { background: #dafbe1; color: #1a7f37; }
-    .badge.down     { background: #ffebe9; color: #cf222e; }
-    .badge.unknown  { background: #eef0f3; color: #57606a; }
+    .badge.up       { background: rgba(79,152,163,0.15); color: #4F98A3; }
+    .badge.down     { background: rgba(248,81,73,0.15); color: #f85149; }
+    .badge.unknown  { background: rgba(139,148,158,0.1); color: #8b949e; }
     .dot { width: 8px; height: 8px; border-radius: 50%; }
-    .dot.up      { background: #1a7f37; }
-    .dot.down    { background: #cf222e; }
-    .dot.unknown { background: #57606a; }
+    .dot.up      { background: #4F98A3; }
+    .dot.down    { background: #f85149; }
+    .dot.unknown { background: #8b949e; }
     footer {
       margin-top: 40px;
       text-align: center;
       font-size: 0.8rem;
-      color: #57606a;
+      color: #8b949e;
     }
-    footer a { color: #0969da; text-decoration: none; }
+    footer a { color: #4F98A3; text-decoration: none; }
     footer a:hover { text-decoration: underline; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- Add inline SVG favicon with teal `#4F98A3` CL monogram (no external file needed)
- Update page title from "Creatorlayer Status" to "Creatorlayer — Status"
- Restyle entire status page to dark theme: `#0B0C10` background, `#161b22` service cards, `#21262d` borders
- Replace GitHub green accent with Creatorlayer teal `#4F98A3` for "operational" badges, banners, status dots, and footer links
- Warning/error states use amber `#d29922` and red `#f85149` respectively

## Test plan
- [ ] Open `index.html` locally — verify dark background, teal accents, and favicon in browser tab
- [ ] Confirm "All systems operational" banner uses teal coloring
- [ ] Confirm "Outage" badges render in red, "Unknown" in gray
- [ ] Verify footer links render in teal
- [ ] Check responsive behavior on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)